### PR TITLE
Update tests.yaml to include Python 3.15 and GraalPython

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,8 +55,6 @@ jobs:
           - pypy3.9
           - pypy3.10
           - pypy3.11
-          - graalpy3.8
-          - graalpy3.10
           - graalpy3.11
           - graalpy3.12
         exclude:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           - 3.13
           - 3.14
           - 3.14+freethreaded
-          - 3.15+gil
+          - 3.15
           - 3.15+freethreaded
           - pypy3.8
           - pypy3.9

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,10 +49,16 @@ jobs:
           - 3.13
           - 3.14
           - 3.14+freethreaded
+          - 3.15+gil
+          - 3.15+freethreaded
           - pypy3.8
           - pypy3.9
           - pypy3.10
           - pypy3.11
+          - graalpy3.8
+          - graalpy3.10
+          - graalpy3.11
+          - graalpy3.12
         exclude:
           - platform: windows-latest # pypy 3.8 appears broken on Windows
             python: pypy3.8

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -62,6 +62,10 @@ jobs:
         exclude:
           - platform: windows-latest # pypy 3.8 appears broken on Windows
             python: pypy3.8
+          - platform: windows-latest  # Graalpy no like Windows
+            python: graalpy3.11
+          - platform: windows-latest  # Graalpy no like Windows
+            python: graalpy3.12          
       fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Added support for Python 3.15 and GraalPython versions.

## Summary by Sourcery

Expand the test matrix to cover additional Python runtimes.

CI:
- Add CPython 3.15 (GIL and free-threaded variants) to the GitHub Actions test matrix.
- Add GraalPython 3.8, 3.10, 3.11, and 3.12 to the GitHub Actions test matrix.