### PR TITLE
feat: add Python 3.15 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,6 +49,8 @@ jobs:
           - 3.13
           - 3.14
           - 3.14+freethreaded
+          - 3.15
+          - 3.15+freethreaded
           - pypy3.8
           - pypy3.9
           - pypy3.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Framework :: Pytest",
     "Natural Language :: English",
     "Operating System :: OS Independent",


### PR DESCRIPTION
## Summary by Sourcery

Add official support for Python 3.15 across packaging metadata and CI test matrix.

Build:
- Declare Python 3.15 support in the project classifiers in pyproject.toml.

CI:
- Extend the GitHub Actions test matrix to run tests on Python 3.15, including the free-threaded variant.