### PR TITLE
ci: fix release drafter permissions and deprecations

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,13 +1,16 @@
 categories:
   - title: "New Features"
-    labels:
-      - "enhancement"
+    when:
+      labels:
+        - "enhancement"
   - title: "Maintenance"
-    labels:
-      - "maintenance"
+    when:
+      labels:
+        - "maintenance"
   - title: "Bug Fixes"
-    labels:
-      - "bug"
+    when:
+      labels:
+        - "bug"
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   Special thanks to the contributors that made this release happen: $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -10,6 +10,9 @@ concurrency:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - name: Release Drafter
         uses: release-drafter/release-drafter@v7.5.1


### PR DESCRIPTION
## Summary by Sourcery

Update Release Drafter configuration and workflow permissions to align with current schema and required access.

CI:
- Adjust Release Drafter category configuration to use the modern `when.labels` syntax.
- Grant explicit `contents: write` and `pull-requests: read` permissions to the Release Drafter workflow job.