### PR TITLE
chore(renovate): automerge all patch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,6 @@
       "schedule": ["at any time"]
     },
     {
-      "matchManagers": ["pre-commit"],
       "matchUpdateTypes": ["patch"],
       "automerge": true
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,11 @@
       "matchManagers": ["pep621"],
       "automerge": true,
       "schedule": ["at any time"]
+    },
+    {
+      "matchManagers": ["pre-commit"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
     }
   ],
   "lockFileMaintenance": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,7 @@
     }
   ],
   "lockFileMaintenance": {
-    "enabled": true,
+    "enabled": true
   },
   "pre-commit": {
     "enabled": true


### PR DESCRIPTION
## Summary by Sourcery

Configure Renovate to automatically merge patch-level updates for pre-commit hook dependencies.