### PR TITLE
chore: ignore renovate updates for older python dependencies via packageRules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,12 +26,12 @@
     },
     {
       "matchPackageNames": ["hypothesis"],
-      "matchCurrentValue": ">=6.78,<6.156",
+      "matchCurrentValue": "/^>=6\\.78,<6\\.156$/",
       "enabled": false
     },
     {
       "matchPackageNames": ["pytest-check"],
-      "matchCurrentValue": "<2.8.1",
+      "matchCurrentValue": "/^<2\\.8\\.1$/",
       "enabled": false
     }
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,21 @@
     {
       "matchUpdateTypes": ["patch"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["pytest"],
+      "matchCurrentValue": "/^(>=8,<9|>=8\\.0\\.0,<9|>=7,<9)$/",
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["hypothesis"],
+      "matchCurrentValue": ">=6.78,<6.156",
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["pytest-check"],
+      "matchCurrentValue": "<2.8.1",
+      "enabled": false
     }
   ],
   "lockFileMaintenance": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "pytest_time"
 dynamic = ["version", "readme"]
 dependencies = [
     "pytest>=9; python_version >= '3.10'",
-    # renovate: ignore
     "pytest>=8,<9; python_version < '3.10'",
 ]
 classifiers = [
@@ -39,10 +38,8 @@ pytest_time = "pytest_time"
 dev-dependencies = [
     "coverage>=7.3.1",
     "hypothesis>=6.78; (implementation_name != 'pypy' and implementation_name != 'graalpy') or (implementation_name == 'pypy' and python_version >= '3.11')",
-    # renovate: ignore
     "hypothesis>=6.78,<6.156; (implementation_name == 'pypy' and python_version < '3.11') or implementation_name == 'graalpy'",
     "pytest>=9; python_version >= '3.10'",
-    # renovate: ignore
     "pytest>=8.0.0,<9; python_version < '3.10'",
     "pytest-check>=2.0",
     "pytest-cov>=4.1.0",
@@ -89,9 +86,7 @@ type-hints = [
     "types-setuptools>=73.0.0.20240822",
 ]
 lint-38 = [
-    # renovate: ignore
     "pytest>=7,<9; python_version == '3.8'",  # Dropped Python 3.8 support
-    # renovate: ignore
     "pytest-check<2.8.1; python_version == '3.8'",  # Dropped Python 3.8 support
 ]
 docs = [


### PR DESCRIPTION
## Summary by Sourcery

Configure dependency update behavior to ignore older Python-specific dependency ranges via Renovate rules instead of inline pyproject comments.

Enhancements:
- Clean up pyproject.toml by removing inline Renovate ignore comments around legacy pytest and hypothesis constraints.

CI:
- Adjust Renovate configuration to control updates for legacy Python dependency ranges via package rules.